### PR TITLE
exclude src/test from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "babel.js",
-    "babel.min.js"
+    "babel.min.js",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "build": "gulp build",
     "test": "mocha"
   },
+  "files": [
+    "babel.js",
+    "babel.min.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Daniel15/babel-standalone.git"


### PR DESCRIPTION
When you `npm install` you get the src/ and test/ folders too.

Although we removed babel-browser and all that, I kinda want us to support this again haha