### PR TITLE
relax browser check to include nulls and undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,6 @@ export const version = Babel.version;
 
 // Listen for load event if we're in a browser and then kick off finding and
 // running of scripts with "text/babel" type.
-if (typeof window !== 'undefined' && window !== null && window.addEventListener !== null) {
+if (typeof window !== 'undefined' && window && window.addEventListener) {
   window.addEventListener('DOMContentLoaded', () => runScripts(transform), false);
 }


### PR DESCRIPTION
In our current react-native setup the `window` object's `addEventListener` is `undefined`. The current check for `null` is causing the event listener to fire and subsequently fail in our environment as can be seen in the screenshot. In this patch, I've removed the explicit check for `null` and rely instead on the fact that both `null` and `undefined` are falsy.

<img width="487" alt="screen shot 2016-07-06 at 2 33 51 pm" src="https://cloud.githubusercontent.com/assets/49766/16635666/46fd27d6-4388-11e6-9c06-946ef1d077a3.png">
