### PR TITLE
Fix transformFromAst and add minimal test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export function transform(code, options) {
 }
 
 export function transformFromAst(ast, code, options) {
-  return Babel.transformFromAst(code, processOptions(options));
+  return Babel.transformFromAst(ast, code, processOptions(options));
 }
 
 // All the plugins we should bundle

--- a/test/babel-test.js
+++ b/test/babel-test.js
@@ -16,6 +16,36 @@ describe('babel-standalone', () => {
     );
   });
 
+  it('can translate simple ast', () => {
+    const ast = {
+      "type": "Program",
+      "start": 0,
+      "end": 2,
+      "directives": [],
+      "body": [
+        {
+          "type": "ExpressionStatement",
+          "start": 0,
+          "end": 1,
+          "expression": {
+            "type": "NumericLiteral",
+            "start": 0,
+            "end": 2,
+            "value": 42,
+            "raw": "42"
+          }
+        }
+      ],
+      "sourceType": "module"
+    }
+    const output = Babel.transformFromAst(ast, "42", { presets: ["es2015"]}).code;
+    expect(output).to.be(
+      '"use strict";\n' +
+      '\n' +
+      '42;'
+    );
+  });
+
   it('handles the react preset', () => {
     const output = Babel.transform(
       'const someDiv = <div>{getMessage()}</div>',


### PR DESCRIPTION
The exported `transformFromAst` function did not correctly call the underlying function from Babel - forgetting to pass the AST argument! This fixes the issue & adds a minimal test.