### PR TITLE
Support presets/plugins with options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,12 @@ import {runScripts} from './transformScriptTags';
 function processOptions(options) {
   // Parse preset names
   const presets = (options.presets || []).map(presetName => {
-    let preset;
+    let preset = null;
 
     if (presetName instanceof Array && typeof presetName[0] === 'string') {
-      preset = [availablePresets[presetName[0]]].concat(presetName.slice(1));
+      if (presetName[0] in availablePresets) {
+        preset = [availablePresets[presetName[0]]].concat(presetName.slice(1));
+      }
     } else if (typeof presetName === 'string') {
       preset = availablePresets[presetName];
     } else {
@@ -27,10 +29,12 @@ function processOptions(options) {
 
   // Parse plugin names
   const plugins = (options.plugins || []).map(pluginName => {
-    let plugin;
+    let plugin = null;
     
     if (pluginName instanceof Array && typeof pluginName[0] === 'string') {
-      plugin = [availablePlugins[pluginName[0]]].concat(pluginName.slice(1));
+      if (pluginName[0] in availablePlugins) {
+        plugin = [availablePlugins[pluginName[0]]].concat(pluginName.slice(1));
+      }
     } if (typeof pluginName === 'string') {
       plugin = availablePlugins[pluginName];
     } else {

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,13 @@ function processOptions(options) {
     if (presetName instanceof Array && typeof presetName[0] === 'string') {
       if (presetName[0] in availablePresets) {
         preset = [availablePresets[presetName[0]]].concat(presetName.slice(1));
+
+        // workaround for babel issue
+        // at some point, babel copies the preset, losing the non-enumerable
+        // buildPreset key; convert it into an enumerable key.
+        if (typeof preset[0] === 'object' && 'buildPreset' in preset[0]) {
+          preset[0] = { ...preset[0], buildPreset: preset[0].buildPreset }
+        }
       }
     } else if (typeof presetName === 'string') {
       preset = availablePresets[presetName];
@@ -30,7 +37,7 @@ function processOptions(options) {
   // Parse plugin names
   const plugins = (options.plugins || []).map(pluginName => {
     let plugin = null;
-    
+
     if (pluginName instanceof Array && typeof pluginName[0] === 'string') {
       if (pluginName[0] in availablePlugins) {
         plugin = [availablePlugins[pluginName[0]]].concat(pluginName.slice(1));
@@ -41,7 +48,7 @@ function processOptions(options) {
       // Could be an actual plugin module
       return pluginName;
     }
-    
+
     if (!plugin) {
       throw new Error(`Invalid plugin specified in Babel options: "${pluginName}"`);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function processOptions(options) {
       if (pluginName[0] in availablePlugins) {
         plugin = [availablePlugins[pluginName[0]]].concat(pluginName.slice(1));
       }
-    } if (typeof pluginName === 'string') {
+    } else if (typeof pluginName === 'string') {
       plugin = availablePlugins[pluginName];
     } else {
       // Could be an actual plugin module

--- a/src/index.js
+++ b/src/index.js
@@ -8,16 +8,21 @@ import {runScripts} from './transformScriptTags';
 function processOptions(options) {
   // Parse preset names
   const presets = (options.presets || []).map(presetName => {
-    if (typeof presetName === 'string') {
-      var preset = availablePresets[presetName];
-      if (!preset) {
-        throw new Error(`Invalid preset specified in Babel options: "${presetName}"`);
-      }
-      return preset;
+    let preset;
+
+    if (presetName instanceof Array && typeof presetName[0] === 'string') {
+      preset = [availablePresets[presetName[0]]].concat(presetName.slice(1));
+    } else if (typeof presetName === 'string') {
+      preset = availablePresets[presetName];
     } else {
       // Could be an actual preset module
       return presetName;
     }
+
+    if (!preset) {
+      throw new Error(`Invalid preset specified in Babel options: "${presetName}"`);
+    }
+    return preset;
   });
 
   // Parse plugin names

--- a/src/index.js
+++ b/src/index.js
@@ -27,16 +27,21 @@ function processOptions(options) {
 
   // Parse plugin names
   const plugins = (options.plugins || []).map(pluginName => {
-    if (typeof pluginName === 'string') {
-      var plugin = availablePlugins[pluginName];
-      if (!plugin) {
-        throw new Error(`Invalid plugin specified in Babel options: "${pluginName}"`);
-      }
-      return plugin;
+    let plugin;
+    
+    if (pluginName instanceof Array && typeof pluginName[0] === 'string') {
+      plugin = [availablePlugins[pluginName[0]]].concat(pluginName.slice(1));
+    } if (typeof pluginName === 'string') {
+      plugin = availablePlugins[pluginName];
     } else {
       // Could be an actual plugin module
       return pluginName;
     }
+    
+    if (!plugin) {
+      throw new Error(`Invalid plugin specified in Babel options: "${pluginName}"`);
+    }
+    return plugin;
   });
 
   return {

--- a/test/babel-test.js
+++ b/test/babel-test.js
@@ -83,6 +83,16 @@ describe('babel-standalone', () => {
     );
   });
 
+  it('handles plugins with options', () => {
+    const output = Babel.transform(
+      '`${x}`',
+      {plugins: [['transform-es2015-template-literals', {spec: true}]]}
+    ).code;
+    expect(output).to.be(
+      '"" + String(x);'
+    );
+  })
+
   it('throws on invalid preset name', () => {
     expect(
       () => Babel.transform('var foo', {presets: ['lolfail']})

--- a/test/babel-test.js
+++ b/test/babel-test.js
@@ -60,6 +60,16 @@ describe('babel-standalone', () => {
     );
   });
 
+  it('handles presets with options', () => {
+    const output = Babel.transform(
+      'export let x',
+      {presets: [['es2015', { modules: false }]]}
+    ).code;
+    expect(output).to.be(
+      'export var x = void 0;'
+    )
+  });
+
   it('handles specifying a plugin by name', () => {
     const output = Babel.transform(
       'const getMessage = () => "Hello World"',


### PR DESCRIPTION
If the preset/plugin is an array and the first argument is a string, try to look it up in the `available{Presets,Plugins}` objects.